### PR TITLE
Use up-to-date transformers library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     zip_safe=True,
     install_requires=[
         "torch>=1.7",
-        "transformers==4.10.2",
+        "transformers>=4.10.2",
         "sentencepiece",
     ],
     test_require=[


### PR DESCRIPTION
New and useful fixes have been added to the transformers library since the 4.10.2 release from September 2021 (https://github.com/huggingface/transformers/pull/13220). Can we remove the `transformers==4.10.2` restriction from `setup.py`, so that including `adaptor` in the dependencies of a project no longer downgrades `transformers`?