### PR TITLE
Support additional keyword arguments in Adapter.save_model()

### DIFF
--- a/adaptor/adapter.py
+++ b/adaptor/adapter.py
@@ -95,7 +95,7 @@ class Adapter(Trainer):
 
         return out
 
-    def save_model(self, output_dir: Optional[str] = None) -> None:
+    def save_model(self, output_dir: Optional[str] = None, **kwargs) -> None:
         # HF native reload compatibility
         objectives_counter = {str(obj): 0 for obj in self.schedule.objectives["train"].values()}
 


### PR DESCRIPTION
In https://github.com/gaussalgo/adaptor/pull/11, we added support for transformers 4.18.0. Apparently, `Adapter.save_model()` may be called with additional keyword arguments such as `_internal_call: bool` in transformers 4.18.0:

![278222001_391941735924802_7639119211624318328_n](https://user-images.githubusercontent.com/603082/165182239-d827b8f6-d372-4c4a-b886-14457963e539.png)

This pull request adds `**kwargs` to `save_model()`, so that the call does not fail.