### PR TITLE
Do not ignore split in `MaskedLanguageModeling._get_inputs_iterator()`

### DIFF
--- a/adaptor/objectives/MLM.py
+++ b/adaptor/objectives/MLM.py
@@ -60,10 +60,13 @@ class MaskedLanguageModeling(UnsupervisedObjective):
         :param split: Data split. `train` or `eval`.
         :return:
         """
-        if self.texts is not None:
-            texts_iter = iter(self.texts)
+        texts = self.texts if split == 'train' else self.val_texts
+        texts_path = self.texts_path if split == 'train' else self.val_texts_path
+
+        if texts is not None:
+            texts_iter = iter(texts)
         else:
-            texts_iter = AdaptationDataset.iter_text_file_per_line(self.texts_path)
+            texts_iter = AdaptationDataset.iter_text_file_per_line(texts_path)
 
         collated_iter = self._mask_some_tokens(texts_iter)
         return collated_iter


### PR DESCRIPTION
`MaskedLanguageModeling` uses training dataset for both training and evaluation. This pull request fixes that.