### PR TITLE
Introducting objective-agnostic distillation functionality

### DIFF
--- a/adaptor/lang_module.py
+++ b/adaptor/lang_module.py
@@ -150,7 +150,12 @@ class LangModule(torch.nn.Module):
         :param inputs: given head input arguments with corresponding values.
         :return: Raw model outputs (logits).
         """
-        selected_head_model = self.trainable_models[str(inputs["oid"])]
+        try:
+            selected_head_model = self.trainable_models[str(inputs["oid"])]
+        except KeyError:
+            raise ValueError("Requesting inference with the objective having no registered head."
+                             "If you are using `extra_eval_objectives`, "
+                             "do not forget to fill in their `share_other_objective_head`.")
         # include only correct inputs for a specific model
         list_of_model_specific_inputs = inspect.getfullargspec(selected_head_model.forward).args
         model_specific_inputs = {k: v for k, v in inputs.items() if k in list_of_model_specific_inputs}

--- a/adaptor/objectives/distillation.py
+++ b/adaptor/objectives/distillation.py
@@ -1,0 +1,168 @@
+import abc
+import inspect
+from typing import Optional, Union, Dict, Any, Tuple
+
+import torch
+from torch.nn import CrossEntropyLoss, CosineEmbeddingLoss
+from torch.nn.functional import log_softmax, softmax
+from transformers import BatchEncoding, PreTrainedModel
+from transformers.utils import ModelOutput
+
+from adaptor.lang_module import LangModule
+from adaptor.objectives.objective_base import Objective
+
+
+class Distillation(Objective, abc.ABC):
+
+    def __init__(self, *args,
+                 distilled_model: PreTrainedModel,
+                 temperature: int = 1,
+                 logits_ce_loss_weight: int = 1,
+                 hidden_cossim_loss_weight: int = 1,
+                 add_hidden_states_loss: bool = False,
+                 restrict_loss_to_mask: bool = False,
+                 **kwargs):
+        self.teacher_model = distilled_model
+
+        self.temperature = temperature
+        self.logits_ce_loss_weight = logits_ce_loss_weight
+        self.hidden_cossim_loss_weight = hidden_cossim_loss_weight
+
+        self.restrict_loss_to_mask = restrict_loss_to_mask
+        self.add_hidden_states_loss = add_hidden_states_loss
+
+        if add_hidden_states_loss:
+            # in this case, we'll need the teacher to yield the hidden states in the output
+            self.teacher_model.config.output_hidden_states = True
+
+        super().__init__(*args, **kwargs)
+
+    def register_compatible_head_model(self,
+                                       lang_module: LangModule,
+                                       other_objective: Optional["Objective"] = None,
+                                       objective_args_for_head_config: Optional[Dict[str, Any]] = None,
+                                       preloaded_module: Optional[torch.nn.Module] = None) -> torch.nn.Module:
+        if self.add_hidden_states_loss:
+            # if the loss is computed also from the hidden_states, we make sure they are actually requested
+            if objective_args_for_head_config is not None:
+                objective_args_for_head_config["output_hidden_states"] = True
+            else:
+                objective_args_for_head_config = {"output_hidden_states": True}
+        return super(Distillation, self).register_compatible_head_model(lang_module,
+                                                                        other_objective,
+                                                                        objective_args_for_head_config,
+                                                                        preloaded_module)
+
+    def _loss_for_hidden_states(self,
+                                student_hidden: Tuple[torch.FloatTensor],
+                                teacher_hidden: Tuple[torch.FloatTensor],
+                                attn_mask: torch.LongTensor,
+                                teacher_select_method: str = "alternate") -> torch.FloatTensor:
+        assert student_hidden[0].shape[-1] == teacher_hidden[0].shape[-1], \
+            "If adding loss of the hidden states, student and teacher must have embeddings of the same dimension."
+
+        cosine_loss = CosineEmbeddingLoss(reduction="mean")
+
+        # student_hidden = torch.vstack(student_hidden)
+        # teacher_hidden = torch.vstack(teacher_hidden)
+
+        if teacher_select_method == "alternate":
+            teacher_student_ratio = len(teacher_hidden) / len(student_hidden)
+            assert teacher_student_ratio >= 1.0, "Number of teacher's hidden states (%s) " \
+                                                 "must bigger than the student's: (%s)" \
+                                                 % (len(teacher_hidden), len(student_hidden))
+
+            # select every n-th hidden state of the teacher, as in DistilBERT implementation
+            # if the former size is not the multiplier of the latter, we select approximately proportional layers
+            selected_teacher_hs = torch.arange(0, len(teacher_hidden), teacher_student_ratio).long()
+            teacher_hidden_selected = [hidden for i, hidden in enumerate(teacher_hidden) if i in selected_teacher_hs]
+        else:
+            raise ValueError("Unknown teacher_select_method: %s" % teacher_select_method)
+
+        student_hidden = torch.vstack([h.unsqueeze(0) for h in student_hidden])
+        teacher_hidden_selected = torch.vstack([h.unsqueeze(0) for h in teacher_hidden_selected])
+
+        if self.restrict_loss_to_mask:
+            attn_mask_reshaped = attn_mask.unsqueeze(-1).unsqueeze(0).expand_as(student_hidden).bool()
+
+            student_hidden_flat = torch.masked_select(student_hidden, attn_mask_reshaped)
+            teacher_hidden_selected_flat = torch.masked_select(teacher_hidden_selected, attn_mask_reshaped)
+
+            student_hidden_unbatched = student_hidden_flat.reshape(-1, student_hidden.shape[-1])
+            teacher_hidden_unbatched = teacher_hidden_selected_flat.reshape(-1, student_hidden.shape[-1])
+        else:
+            student_hidden_unbatched = student_hidden.reshape(-1, student_hidden.shape[-1])
+            teacher_hidden_unbatched = teacher_hidden_selected.reshape(-1, student_hidden.shape[-1])
+
+        similarity_or_distance_loss = torch.ones(student_hidden_unbatched.shape[0])
+
+        return cosine_loss(student_hidden_unbatched, teacher_hidden_unbatched, similarity_or_distance_loss)
+
+    def _hidden_states_loss(self,
+                            student_outputs: ModelOutput,
+                            teacher_outputs: ModelOutput,
+                            attn_mask: torch.LongTensor) -> torch.FloatTensor:
+        if hasattr(teacher_outputs, "hidden_states"):
+            assert hasattr(student_outputs, "hidden_states"), "Student and teacher must be of the same type"
+            student_hidden = student_outputs.hidden_states
+            teacher_hidden = teacher_outputs.hidden_states
+
+            loss = self._loss_for_hidden_states(student_hidden, teacher_hidden, attn_mask)
+
+        elif hasattr(teacher_outputs, "encoder_hidden_states") and hasattr(teacher_outputs, "decoder_hidden_states"):
+            assert hasattr(student_outputs, "encoder_hidden_states") \
+                   and hasattr(teacher_outputs, "decoder_hidden_states"), "Student and teacher must be of the same type"
+
+            student_encoder_hidden = student_outputs.encoder_hidden_states
+            teacher_encoder_hidden = teacher_outputs.encoder_hidden_states
+            student_decoder_hidden = student_outputs.decoder_hidden_states
+            teacher_decoder_hidden = teacher_outputs.decoder_hidden_states
+
+            loss = (self._loss_for_hidden_states(student_encoder_hidden, teacher_encoder_hidden, attn_mask) +
+                    self._loss_for_hidden_states(student_decoder_hidden, teacher_decoder_hidden, attn_mask))
+        else:
+            raise ValueError("Please initialize teacher model with `output_hidden_states=True`")
+
+        return loss
+
+    def _compute_loss(self,
+                      student_logits: torch.FloatTensor,
+                      labels: torch.LongTensor,
+                      inputs: Optional[Union[BatchEncoding, Dict[str, torch.Tensor]]] = None) -> torch.FloatTensor:
+        assert inputs is not None, "Distillation loss requires model inputs to be passed"
+
+        ce_loss = CrossEntropyLoss()
+
+        teacher_inputs = inspect.getfullargspec(self.teacher_model.forward).args
+        with torch.no_grad():
+            teacher_outputs = self.teacher_model(**{k: v for k, v in inputs.items() if k in teacher_inputs})
+            teacher_logits = teacher_outputs.logits
+
+        if self.restrict_loss_to_mask:
+            # pick only the predictions of tokens on the attended positions (i.e. ignore the others)
+            attn_mask_reshaped = inputs["attention_mask"].unsqueeze(-1).expand_as(student_logits).bool()
+
+            student_logits_flat = torch.masked_select(student_logits, attn_mask_reshaped)
+            student_logits_unbatched = student_logits_flat.reshape(-1, student_logits.shape[-1])
+
+            teacher_logits_flat = torch.masked_select(teacher_logits, attn_mask_reshaped)
+            teacher_logits_unbatched = teacher_logits_flat.reshape(-1, student_logits.shape[-1])
+        else:
+            # we flatten the batch, to get the class scores & probabilities to the 2nd dimension
+            student_logits_unbatched = student_logits.flatten(end_dim=1)
+            teacher_logits_unbatched = teacher_logits.flatten(end_dim=1)
+
+        distil_loss = ce_loss(log_softmax(student_logits_unbatched / self.temperature, dim=-1),
+                              softmax(teacher_logits_unbatched / self.temperature, dim=-1)) * self.temperature ** 2
+        distil_loss = self.logits_ce_loss_weight * distil_loss
+
+        if self.add_hidden_states_loss:
+            student_inputs = inspect.getfullargspec(self.compatible_head_model.forward).args
+            student_outputs = self.compatible_head_model(**{k: v for k, v in inputs.items() if k in student_inputs})
+
+            hidden_loss = self._hidden_states_loss(student_outputs, teacher_outputs, inputs["attention_mask"])
+            hidden_loss_scaled = self.hidden_cossim_loss_weight * hidden_loss
+
+            distil_loss = distil_loss + hidden_loss_scaled
+
+        return distil_loss

--- a/adaptor/objectives/distillation.py
+++ b/adaptor/objectives/distillation.py
@@ -13,16 +13,35 @@ from adaptor.objectives.objective_base import Objective
 
 
 class Distillation(Objective, abc.ABC):
+    """
+    Model-agnostic implementation of distillation, as introduced in DistilBERT paper: https://arxiv.org/abs/1910.01108
+    This implementation will work out-of-box with default parameters for models with the same prediction dimensionality
+    (= number of categories, or vocab size for LMs).
+    Note that objectives can occasionally produce more than one output: currently only in ExtractiveQA;
+    in such cases, the model prediction can be flattened in a custom wrapper.
+    """
 
     def __init__(self, *args,
-                 distilled_model: PreTrainedModel,
+                 teacher_model: PreTrainedModel,
                  temperature: int = 1,
                  logits_ce_loss_weight: int = 1,
                  hidden_cossim_loss_weight: int = 1,
                  add_hidden_states_loss: bool = False,
                  restrict_loss_to_mask: bool = False,
                  **kwargs):
-        self.teacher_model = distilled_model
+        """
+        See the distillation parameters description in https://arxiv.org/abs/1910.01108.
+        :param teacher_model: A model to distill the prediction from.
+        :param temperature: Distillation intensity; The smaller, the stronger. See DistilBERT paper for details.
+        :param logits_ce_loss_weight: Relative weight of Logits' cross-entropy loss.
+        :param hidden_cossim_loss_weight: Relative weights of hidden states loss.
+        :param add_hidden_states_loss: Whether to also include hidden states loss.
+            Note that hidden states' loss will work only when distilling from the model
+            with same hidden states' dimensionality. Defaults to false.
+        :param restrict_loss_to_mask: Whether to compute selected losses only from the attended positions
+            (set to True), or from all positions (default, set to False)
+        """
+        self.teacher_model = teacher_model
 
         self.temperature = temperature
         self.logits_ce_loss_weight = logits_ce_loss_weight
@@ -48,10 +67,11 @@ class Distillation(Objective, abc.ABC):
                 objective_args_for_head_config["output_hidden_states"] = True
             else:
                 objective_args_for_head_config = {"output_hidden_states": True}
-        return super(Distillation, self).register_compatible_head_model(lang_module,
-                                                                        other_objective,
-                                                                        objective_args_for_head_config,
-                                                                        preloaded_module)
+
+        return super().register_compatible_head_model(lang_module,
+                                                      other_objective,
+                                                      objective_args_for_head_config,
+                                                      preloaded_module)
 
     def _loss_for_hidden_states(self,
                                 student_hidden: Tuple[torch.FloatTensor],
@@ -62,9 +82,6 @@ class Distillation(Objective, abc.ABC):
             "If adding loss of the hidden states, student and teacher must have embeddings of the same dimension."
 
         cosine_loss = CosineEmbeddingLoss(reduction="mean")
-
-        # student_hidden = torch.vstack(student_hidden)
-        # teacher_hidden = torch.vstack(teacher_hidden)
 
         if teacher_select_method == "alternate":
             teacher_student_ratio = len(teacher_hidden) / len(student_hidden)
@@ -83,14 +100,17 @@ class Distillation(Objective, abc.ABC):
         teacher_hidden_selected = torch.vstack([h.unsqueeze(0) for h in teacher_hidden_selected])
 
         if self.restrict_loss_to_mask:
+            # compute loss only from the attended positions
             attn_mask_reshaped = attn_mask.unsqueeze(-1).unsqueeze(0).expand_as(student_hidden).bool()
 
             student_hidden_flat = torch.masked_select(student_hidden, attn_mask_reshaped)
             teacher_hidden_selected_flat = torch.masked_select(teacher_hidden_selected, attn_mask_reshaped)
 
+            # we flatten the batch, to get the class scores & probabilities to the 2nd dimension
             student_hidden_unbatched = student_hidden_flat.reshape(-1, student_hidden.shape[-1])
             teacher_hidden_unbatched = teacher_hidden_selected_flat.reshape(-1, student_hidden.shape[-1])
         else:
+            # we flatten the batch, to get the class scores & probabilities to the 2nd dimension
             student_hidden_unbatched = student_hidden.reshape(-1, student_hidden.shape[-1])
             teacher_hidden_unbatched = teacher_hidden_selected.reshape(-1, student_hidden.shape[-1])
 
@@ -103,6 +123,7 @@ class Distillation(Objective, abc.ABC):
                             teacher_outputs: ModelOutput,
                             attn_mask: torch.LongTensor) -> torch.FloatTensor:
         if hasattr(teacher_outputs, "hidden_states"):
+            # encoder-, or decoder-only
             assert hasattr(student_outputs, "hidden_states"), "Student and teacher must be of the same type"
             student_hidden = student_outputs.hidden_states
             teacher_hidden = teacher_outputs.hidden_states
@@ -110,6 +131,7 @@ class Distillation(Objective, abc.ABC):
             loss = self._loss_for_hidden_states(student_hidden, teacher_hidden, attn_mask)
 
         elif hasattr(teacher_outputs, "encoder_hidden_states") and hasattr(teacher_outputs, "decoder_hidden_states"):
+            # encoder-decoder: sum the losses for both encoder and decoder states
             assert hasattr(student_outputs, "encoder_hidden_states") \
                    and hasattr(teacher_outputs, "decoder_hidden_states"), "Student and teacher must be of the same type"
 
@@ -121,7 +143,7 @@ class Distillation(Objective, abc.ABC):
             loss = (self._loss_for_hidden_states(student_encoder_hidden, teacher_encoder_hidden, attn_mask) +
                     self._loss_for_hidden_states(student_decoder_hidden, teacher_decoder_hidden, attn_mask))
         else:
-            raise ValueError("Please initialize teacher model with `output_hidden_states=True`")
+            raise ValueError("Please initialize both teacher and student model with `output_hidden_states=True`")
 
         return loss
 
@@ -131,6 +153,7 @@ class Distillation(Objective, abc.ABC):
                       inputs: Optional[Union[BatchEncoding, Dict[str, torch.Tensor]]] = None) -> torch.FloatTensor:
         assert inputs is not None, "Distillation loss requires model inputs to be passed"
 
+        # output logits' loss
         ce_loss = CrossEntropyLoss()
 
         teacher_inputs = inspect.getfullargspec(self.teacher_model.forward).args
@@ -145,6 +168,7 @@ class Distillation(Objective, abc.ABC):
             student_logits_flat = torch.masked_select(student_logits, attn_mask_reshaped)
             student_logits_unbatched = student_logits_flat.reshape(-1, student_logits.shape[-1])
 
+            # we flatten the batch, to get the class scores & probabilities to the 2nd dimension
             teacher_logits_flat = torch.masked_select(teacher_logits, attn_mask_reshaped)
             teacher_logits_unbatched = teacher_logits_flat.reshape(-1, student_logits.shape[-1])
         else:
@@ -155,8 +179,10 @@ class Distillation(Objective, abc.ABC):
         distil_loss = ce_loss(log_softmax(student_logits_unbatched / self.temperature, dim=-1),
                               softmax(teacher_logits_unbatched / self.temperature, dim=-1)) * self.temperature ** 2
         distil_loss = self.logits_ce_loss_weight * distil_loss
+        # end output logits' loss
 
         if self.add_hidden_states_loss:
+            # hidden states loss
             student_inputs = inspect.getfullargspec(self.compatible_head_model.forward).args
             student_outputs = self.compatible_head_model(**{k: v for k, v in inputs.items() if k in student_inputs})
 

--- a/adaptor/objectives/objective_base.py
+++ b/adaptor/objectives/objective_base.py
@@ -360,7 +360,8 @@ class Objective(abc.ABC):
         """
         pass
 
-    def register_compatible_head_model(self, lang_module: LangModule,
+    def register_compatible_head_model(self,
+                                       lang_module: LangModule,
                                        other_objective: Optional["Objective"] = None,
                                        objective_args_for_head_config: Optional[Dict[str, Any]] = None,
                                        preloaded_module: Optional[torch.nn.Module] = None) -> torch.nn.Module:

--- a/tests/distillation_test.py
+++ b/tests/distillation_test.py
@@ -1,0 +1,96 @@
+from adaptor.lang_module import LangModule
+from adaptor.objectives.distillation import Distillation
+from adaptor.objectives.objective_base import Objective
+from utils import test_base_models, paths
+
+
+def assert_module_objective_ok(lang_module: LangModule, objective: Objective, split: str = "train"):
+    # dataset iteration test
+    dataset_sample = next(iter(objective.get_dataset(split, objective_i=0, device="cpu")))
+
+    # providing labels makes HF lang_module to compute its own loss, which is in DA redundantly done by Objective
+    outputs = lang_module(**dataset_sample)
+
+    loss = objective.compute_loss(outputs, dataset_sample["labels"], dataset_sample, split)
+
+    # check that retrieved loss has a backward_fn
+    loss.backward()
+
+    assert True
+
+
+def test_distillation_seq():
+    from adaptor.objectives.seq2seq import Sequence2Sequence
+    from transformers import AutoModelForSeq2SeqLM
+
+    class DistilledSeq2Seq(Distillation, Sequence2Sequence):
+        # this is a full implementation of distillation within other objective
+        pass
+
+    lang_module = LangModule(test_base_models["translation_mono"])
+    distilled_model = AutoModelForSeq2SeqLM.from_pretrained(test_base_models["translation_mono"])
+
+    objective = DistilledSeq2Seq(lang_module,
+                                 distilled_model=distilled_model,
+                                 texts_or_path=paths["texts"]["translation"],
+                                 labels_or_path=paths["labels"]["translation"],
+                                 batch_size=4)
+
+    assert_module_objective_ok(lang_module, objective)
+
+
+def test_distillation_mlm():
+    from adaptor.objectives.MLM import MaskedLanguageModeling
+    from transformers import AutoModelForMaskedLM
+
+    class DistilledMLM(Distillation, MaskedLanguageModeling):
+        pass
+
+    lang_module = LangModule(test_base_models["MLM_student"])
+    distilled_model = AutoModelForMaskedLM.from_pretrained(test_base_models["MLM"])
+
+    objective = DistilledMLM(lang_module,
+                             distilled_model=distilled_model,
+                             texts_or_path=paths["texts"]["unsup"],
+                             batch_size=4)
+
+    assert_module_objective_ok(lang_module, objective)
+
+
+def test_distillation_mlm_incl_hidden_states():
+    from adaptor.objectives.MLM import MaskedLanguageModeling
+    from transformers import AutoModelForMaskedLM
+
+    class DistilledMLM(Distillation, MaskedLanguageModeling):
+        pass
+
+    lang_module = LangModule(test_base_models["MLM_student"])
+    distilled_model = AutoModelForMaskedLM.from_pretrained(test_base_models["MLM"])
+
+    objective = DistilledMLM(lang_module,
+                             distilled_model=distilled_model,
+                             add_hidden_states_loss=True,
+                             texts_or_path=paths["texts"]["unsup"],
+                             batch_size=4)
+
+    assert_module_objective_ok(lang_module, objective)
+
+
+def test_distillation_mlm_restrict_to_attention():
+    from adaptor.objectives.MLM import MaskedLanguageModeling
+    from transformers import AutoModelForMaskedLM
+
+    class DistilledMLM(Distillation, MaskedLanguageModeling):
+        pass
+
+    lang_module = LangModule(test_base_models["MLM_student"])
+    distilled_model = AutoModelForMaskedLM.from_pretrained(test_base_models["MLM"])
+
+    objective = DistilledMLM(lang_module,
+                             distilled_model=distilled_model,
+                             add_hidden_states_loss=True,
+                             restrict_loss_to_mask=True,
+                             texts_or_path=paths["texts"]["unsup"],
+                             batch_size=4)
+
+    assert_module_objective_ok(lang_module, objective)

--- a/tests/distillation_test.py
+++ b/tests/distillation_test.py
@@ -31,7 +31,7 @@ def test_distillation_seq():
     distilled_model = AutoModelForSeq2SeqLM.from_pretrained(test_base_models["translation_mono"])
 
     objective = DistilledSeq2Seq(lang_module,
-                                 distilled_model=distilled_model,
+                                 teacher_model=distilled_model,
                                  texts_or_path=paths["texts"]["translation"],
                                  labels_or_path=paths["labels"]["translation"],
                                  batch_size=4)
@@ -50,7 +50,7 @@ def test_distillation_mlm():
     distilled_model = AutoModelForMaskedLM.from_pretrained(test_base_models["MLM"])
 
     objective = DistilledMLM(lang_module,
-                             distilled_model=distilled_model,
+                             teacher_model=distilled_model,
                              texts_or_path=paths["texts"]["unsup"],
                              batch_size=4)
 
@@ -68,7 +68,7 @@ def test_distillation_mlm_incl_hidden_states():
     distilled_model = AutoModelForMaskedLM.from_pretrained(test_base_models["MLM"])
 
     objective = DistilledMLM(lang_module,
-                             distilled_model=distilled_model,
+                             teacher_model=distilled_model,
                              add_hidden_states_loss=True,
                              texts_or_path=paths["texts"]["unsup"],
                              batch_size=4)
@@ -87,7 +87,7 @@ def test_distillation_mlm_restrict_to_attention():
     distilled_model = AutoModelForMaskedLM.from_pretrained(test_base_models["MLM"])
 
     objective = DistilledMLM(lang_module,
-                             distilled_model=distilled_model,
+                             teacher_model=distilled_model,
                              add_hidden_states_loss=True,
                              restrict_loss_to_mask=True,
                              texts_or_path=paths["texts"]["unsup"],

--- a/tests/objectives_test.py
+++ b/tests/objectives_test.py
@@ -9,10 +9,6 @@ from adaptor.objectives.question_answering import ExtractiveQA
 from adaptor.objectives.seq2seq import Sequence2Sequence
 from utils import paths, test_base_models
 
-unsup_target_domain_texts = "mock_data/domain_unsup.txt"
-sup_target_domain_texts = "mock_data/supervised_texts.txt"
-sup_target_domain_labels = "mock_data/supervised_texts_token_labels.txt"
-
 
 def assert_module_objective_ok(lang_module: LangModule, objective: Objective, split: str = "train"):
     # dataset iteration test

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,15 @@ paths = {
 test_base_models = {
     "translation_mono": "Helsinki-NLP/opus-mt-en-cs",
     "translation_multi": {
-            "model": "sshleifer/tiny-mbart",
-            "test_src_lang": "en_XX",
-            "test_tgt_lang": "cs_CZ"},
-    "token_classification": "bert-base-multilingual-cased",
-    "sequence_classification": "bert-base-multilingual-cased",
-    "extractive_QA": "Unbabel/xlm-roberta-comet-small"
+        "model": "sshleifer/tiny-mbart",
+        "test_src_lang": "en_XX",
+        "test_tgt_lang": "cs_CZ"
+    },
+    "token_classification": "bert-base-cased",
+    "sequence_classification": "bert-base-cased",
+    "extractive_QA": "Unbabel/xlm-roberta-comet-small",
+    "MLM": "bert-base-cased",
+    "MLM_student": "distilbert-base-cased"
 }
 
 training_arguments = AdaptationArguments(output_dir="adaptation_output_dir",


### PR DESCRIPTION
This PR implements the `Distillation` objective, allowing to transpose any existing Objective to its distilled version:
```python
class DistilledSeq2Seq(Distillation, Sequence2Sequence):
    pass

class DistilledMLM(Distillation, MaskedLanguageModeling):
    pass
```
Currently, CI tests Distillation of MLM and Seq2Seq; See [tests/distillation_test.py](https://github.com/gaussalgo/adaptor/blob/cab5d116b9bd9662e2bc4f499a74637e61be6a8b/tests/distillation_test.py)
