### PR TITLE
SupervisedObjective: kwargs inference before head registration: bug fix

### DIFF
--- a/adaptor/objectives/objective_base.py
+++ b/adaptor/objectives/objective_base.py
@@ -513,7 +513,7 @@ class SupervisedObjective(Objective, abc.ABC):
 
             self.labels_map = {val: i for i, val in enumerate(sorted(set(all_labels)))}
 
-            objective_args_for_head_config = {"num_labels": len(all_labels),
+            objective_args_for_head_config = {"num_labels": len(self.labels_map),
                                               "label2id": self.labels_map,
                                               "id2label": {v: k for k, v in self.labels_map.items()},
                                               **objective_args_for_head_config}

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     zip_safe=True,
     install_requires=[
         "torch>=1.7",
-        "transformers>=4.10.2<=4.19.1",  # upper-closed on 4.19.1 for now, due to minor bug in eval loss logging, but otherwise works with 4.27.1
+        "transformers>=4.10.2<=4.19.1",  # upper-closed on 4.19.1 for now, due to minor bug in eval loss logging
         "sentencepiece",
     ],
     test_require=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="adaptor",
-    version='0.2.0',
+    version='0.2.1',
     description="Adaptor: Objective-centric Adaptation Framework for Language Models.",
     long_description_content_type="text/markdown",
     long_description=readme,
@@ -30,7 +30,7 @@ setup(
     zip_safe=True,
     install_requires=[
         "torch>=1.7",
-        "transformers>=4.10.2",  # intentionally open dependency, but tested with transformers==4.18.0
+        "transformers>=4.10.2<=4.19.1",  # upper-closed on 4.19.1 for now, due to minor bug in eval loss logging, but otherwise works with 4.27.1
         "sentencepiece",
     ],
     test_require=[


### PR DESCRIPTION
This PR patches bug in the automated inference of head configuration based on a number of labels.