### PR TITLE
Recursive modules gradient checkpoining & transformers version fix

### DIFF
--- a/adaptor/lang_module.py
+++ b/adaptor/lang_module.py
@@ -183,3 +183,8 @@ class LangModule(torch.nn.Module):
         torch.manual_seed(seed)
         for head, head_model in self.trainable_models.items():
             head_model.apply(reinit_model_weights)
+
+    def gradient_checkpointing_enable(self):
+        for module_id, module in self.trainable_models.items():
+            if hasattr(module, "gradient_checkpointing_enable"):
+                module.gradient_checkpointing_enable()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     zip_safe=True,
     install_requires=[
         "torch>=1.7",
-        "transformers>=4.10.2<=4.19.1",  # upper-closed on 4.19.1 for now, due to minor bug in eval loss logging
+        "transformers>=4.10.2,<=4.19.1",  # upper-closed on 4.19.1 for now, due to minor bug in eval loss logging
         "sentencepiece",
     ],
     test_require=[


### PR DESCRIPTION
This PR adds support for `gradient_checkpointing` that can save some GPU memory in LLMs over 3B params. It also fixes incorrect resolution of `transformers` version in the previous version.